### PR TITLE
Dockerfile pulls ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 # Install yarp prerequisites
 RUN apt update && apt install -y wget unzip \


### PR DESCRIPTION
Updating the base image of the docker to make it consistent with the apt packages requested for yarp. 